### PR TITLE
Fix typo in reference to included file GFMUAddon.class.php

### DIFF
--- a/GFMUAddon.class.php
+++ b/GFMUAddon.class.php
@@ -190,7 +190,7 @@ class GFMUAddon extends GFAddOn
         $this->pluploaderHandler = GFMUHandlePluploader::getInstance();
 
         if ($this->is_gravityforms_supported() and class_exists('GF_Field')) {
-            require_once(GFMU_INC_PATH . 'GF_MultiUploader_Field.class.php');
+            require_once(GFMU_INC_PATH . 'gf_multiuploader_field.class.php');
             GF_Fields::register(new GF_MultiUploader_Field());
         }
     }


### PR DESCRIPTION
the GFMUAddon.class.php file references the file inc/gf_multiuploader_field.class.php, but it referenced it as so: GF_MultiUploader_Field.class.php. This caused a fatal error on one site I was working on. I temporarily changed the file name to GF_MultiUploader_Field.class.php until there's a fix.